### PR TITLE
use write instead of write_chunked

### DIFF
--- a/eris.pl
+++ b/eris.pl
@@ -731,7 +731,7 @@ group {
     $c->timing->begin('nar_stream');
 
     $stream->on(read => sub ($s, $bytes) {
-      return $c->write_chunk($bytes);
+      return $c->write($bytes);
     });
 
     # record timing info when the stream is finished and close the connection

--- a/t/t03-varnish.nix
+++ b/t/t03-varnish.nix
@@ -1,0 +1,61 @@
+{ pkgs, ... }:
+
+let
+  testPkg = pkgs.writeShellScriptBin "varnish-test" ''
+    echo hello world
+  '';
+
+  configFile = pkgs.writeText "eris.conf" ''
+    {
+      listen => ['http://[::1]:5000'],
+    }
+  '';
+in
+{
+  nodes = {
+    eris = { config, pkgs, ... }:
+      { imports = [ ../module.nix ];
+
+        services.eris-git = {
+          enable = true;
+          configFile = "${configFile}";
+        };
+
+        services.varnish = {
+          enable = true;
+          http_address = "0.0.0.0:80";
+          config = ''
+            vcl 4.0;
+
+            backend eris {
+              .host = "::1";
+              .port = "5000";
+            }
+          '';
+        };
+
+        networking.firewall.allowedTCPPorts = [ 80 ];
+        environment.systemPackages = [ testPkg ];
+      };
+
+    client01 = { config, pkgs, ... }:
+      { imports = [];
+
+        nix.requireSignedBinaryCaches = false;
+        nix.binaryCaches = [ "http://eris" ];
+      };
+  };
+
+  testScript = ''
+    startAll;
+    $eris->waitForOpenPort(80);
+    $eris->waitForOpenPort(5000);
+
+    $client01->succeed("curl -f http://eris/v1/version");
+    $client01->succeed("curl -f http://eris/nix-cache-info");
+    $client01->fail("curl -f http://eris/v1/public-key");
+
+    $client01->waitUntilSucceeds("nix copy --from http://eris/ ${testPkg}");
+    $client01->succeed("${testPkg}/bin/varnish-test");
+  '';
+}


### PR DESCRIPTION
###### Motivation for this change
Setting Content-Length to a value, while also setting Transfer-Encoding to chunked is not valid
HTTP. To quote [RFC 7230 Section 3.3.2](https://tools.ietf.org/html/rfc7230#section-3.3.2), "A sender MUST NOT send a Content-Length header field in any message that contains a Transfer-Encoding header field.".

So we either drop chunked or content-length.

Looking at the relevant part of the [mojolicious documentation](https://mojolicious.org/perldoc/Mojolicious/Controller#write), using write instead of write_chunk is probably fine? I'm fine either way, but I'd like this fixed, because…

while libcurl, nginx and haproxy all seem fine with this RFC violation, varnish is not. As in, varnish refuses responses from eris.

###### Things done
- [x] Compiled all jobs with `nix build -f release.nix`
- [x] Ran all tests with `nix build -f release.nix test`
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/thoughtpolice/eris/blob/master/.github/CONTRIBUTING.md).

---

